### PR TITLE
Support for HTTP Auth on request and Fix for bulk index 'percolate'

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -49,15 +49,17 @@ function Client(host, options) {
     this.options = options || {};
 
     this.host    = host || '127.0.0.1';
-    // Include auth informatioh if present
-    if (this.options.auth)
-    {
+    // Include auth information if present
+    if (this.options.auth) {
         this.host = this.options.auth + '@' + this.host;
     }
 
     this.options.port || (this.options.port = 9200);
     this.options.timeout || (this.options.timeout = 60000);
-    (this.options.protocol == 'https:') || (this.options.protocol = 'http:');
+    
+    if (this.options.protocol != 'https:') {
+        this.options.protocol = 'http:';
+    }
     
     this._indexCache = {};
 }
@@ -83,13 +85,12 @@ Client.prototype = {
     /**
     Base URL for this client, of the form "http://host:port".
 
-	+ Modified to support protocol option for https and http
 	
     @property baseUrl
     @type {String}
     **/
     get baseUrl() {	
-		return this.options.protocol + '//' + this.host + ':' + this.options.port;
+        return this.options.protocol + '//' + this.host + ':' + this.options.port;
     },
 
     /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -33,6 +33,11 @@ established as needed and are not persistent.
     @param {Number} [options.timeout=60000] Number of milliseconds to wait
         before aborting a request. Be sure to increase this if you do large bulk
         operations.
+    @param {string} [options.protocol='https'] Protocol to use in request, default 
+        is http:,  will accept https:
+    @param {string} [options.auth='username:password'] Used with Basic HTTP authentication, 
+        default is not to authenticate, note passwords are passed in plain text unless https 
+        is used and receiving server accepts secure traffic.
 @constructor
 **/
 function Client(host, options) {
@@ -41,13 +46,19 @@ function Client(host, options) {
         options = host;
         host    = undefined;
     }
+    this.options = options || {};
 
     this.host    = host || '127.0.0.1';
-    this.options = options || {};
+    // Include auth informatioh if present
+    if (this.options.auth)
+    {
+        this.host = this.options.auth + '@' + this.host;
+    }
 
     this.options.port || (this.options.port = 9200);
     this.options.timeout || (this.options.timeout = 60000);
-
+    (this.options.protocol == 'https:') || (this.options.protocol = 'http:');
+    
     this._indexCache = {};
 }
 
@@ -72,11 +83,13 @@ Client.prototype = {
     /**
     Base URL for this client, of the form "http://host:port".
 
+	+ Modified to support protocol option for https and http
+	
     @property baseUrl
     @type {String}
     **/
-    get baseUrl() {
-        return 'http://' + this.host + ':' + this.options.port;
+    get baseUrl() {	
+		return this.options.protocol + '//' + this.host + ':' + this.options.port;
     },
 
     /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -147,7 +147,7 @@ Index.bulk = function (client, operations, options, callback) {
                 if (name.charAt(0) === '_') {
                     line[action][name] = input[name];
                 } else {
-                    // Current implementation only supports 'percolate' note '_percolate'
+                    // Current implementation only supports 'percolate' not '_percolate'
                     if (name === 'percolate')
                     {
                         line[action][name] = input[name];

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,8 +105,7 @@ adhere to one of the following formats.
 @method bulk
 @param {Client} client Client instance.
 @param {Object[]} operations Array of operations to perform. See above for a
-    description of the expected object format. Note currentlty percolate action 
-    does not have the underscore in front ever.
+    description of the expected object format. 
 @param {Object} [options] Options.
     @param {String} [options.consistency="quorum"] Write consistency to use
         for these operations. Permitted values are "one", "quorum", and "all".

--- a/lib/index.js
+++ b/lib/index.js
@@ -92,6 +92,11 @@ adhere to one of the following formats.
             body : 'Today I ate a sandwich.'
         }}},
 
+        {index: {index: 'blog', type: 'post', id: '3', percolate: '*', data: {
+            title: 'Percolate this',
+            body: 'Run against all percolaters.'
+        }}},
+
         {delete: {index: 'blog', type: 'post', id: '42'}}
     ], function (err, res) {
         // ...
@@ -100,7 +105,8 @@ adhere to one of the following formats.
 @method bulk
 @param {Client} client Client instance.
 @param {Object[]} operations Array of operations to perform. See above for a
-    description of the expected object format.
+    description of the expected object format. Note currentlty percolate action 
+    does not have the underscore in front ever.
 @param {Object} [options] Options.
     @param {String} [options.consistency="quorum"] Write consistency to use
         for these operations. Permitted values are "one", "quorum", and "all".
@@ -142,7 +148,14 @@ Index.bulk = function (client, operations, options, callback) {
                 if (name.charAt(0) === '_') {
                     line[action][name] = input[name];
                 } else {
-                    line[action]['_' + name] = input[name];
+                    // Current implementation only supports 'percolate' note '_percolate'
+                    if (name === 'percolate')
+                    {
+                        line[action][name] = input[name];
+                    }
+                    else {
+                        line[action]['_' + name] = input[name];
+                    }
                 }
             }
         }

--- a/tests/offline-tests.js
+++ b/tests/offline-tests.js
@@ -47,7 +47,7 @@ vows.describe('Elastical').addBatch({
                                 b: 'b'
                             }}},
 
-                            {index: {index: 'blog', type: 'post', id: 'bar', data: {
+                            {index: {index: 'blog', type: 'post', id: 'bar', percolate: '*', data: {
                                 c: 'c',
                                 d: 'd'
                             }}},
@@ -72,7 +72,7 @@ vows.describe('Elastical').addBatch({
                         assert.equal(options.body,
                             '{"create":{"_index":"blog","_type":"post","_id":"foo"}}\n' +
                             '{"a":"a","b":"b"}\n' +
-                            '{"index":{"_index":"blog","_type":"post","_id":"bar"}}\n' +
+                            '{"index":{"_index":"blog","_type":"post","_id":"bar","percolate":"*"}}\n' +
                             '{"c":"c","d":"d"}\n' +
                             '{"delete":{"_index":"blog","_type":"post","_id":"deleteme"}}\n'
                         );
@@ -798,6 +798,22 @@ vows.describe('Elastical').addBatch({
         }
     },
 
+    'Client with authentication': {
+        topic: new elastical.Client({auth: 'username:password'}),
+        
+        '`host` should equal "username:password@127.0.0.1"': function (client) {
+            assert.equal(client.host, 'username:password@127.0.0.1');
+        }
+    },
+    
+    'Client with authentication and https: protocol': {
+        topic: new elastical.Client({auth: 'username:password', protocol: 'https:'}),
+        
+        '`baseUrl` should reflect the protocol and auth settings': function (client) {
+            assert.equal(client.baseUrl, 'https://username:password@127.0.0.1:9200');
+        }
+    },
+    
     'Index': {
         topic: new elastical.Client().getIndex('foo'),
 

--- a/tests/online-tests.js
+++ b/tests/online-tests.js
@@ -26,6 +26,11 @@ vows.describe('Elastical')
                             d: 'd'
                         }}},
 
+                        {index: {index: 'elastical-test-bulk', type: 'post', id: 'baz', percolate: '*', data: {
+                            e: 'bulkpercolate',
+                            f: 'f'
+                        }}},
+
                         {delete: {index: 'elastical-test-bulk', type: 'post', id: 'deleteme'}}
                     ], this.callback);
                 },
@@ -36,7 +41,9 @@ vows.describe('Elastical')
                     assert.isArray(res.items);
                     assert.isTrue(res.items[0].create.ok);
                     assert.isTrue(res.items[1].index.ok);
-                    assert.isTrue(res.items[2].delete.ok);
+                    assert.isTrue(res.items[2].index.ok);
+                    assert.equal(res.items[2].index.matches[0], 'perc');
+                    assert.isTrue(res.items[3].delete.ok);
                 }
             }
         },

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -19,6 +19,14 @@ curl -s -XPUT "$BASE/elastical-test-bulk/post/deleteme" -d '{
   "title": "Delete me"
 }'
 
+curl -s -XPUT "$BASE/_percolator/elastical-test-bulk/perc" -d '{
+    "query" : {
+        "term" : {
+            "e": "bulkpercolate"
+        }
+    }
+}'
+
 curl -s -XPUT "$BASE/elastical-test-get/post/1" -d '{
   "title": "Hello world",
   "body": "Welcome to my stupid blog.",


### PR DESCRIPTION
I've been working with your client and ran into two items I felt could be helpful.

1) Current implementation of elasticsearch does not support _percolate during a bulk index, only 'percolate'  I've modfied the code for this exception, should it be fixed this will not be required but will also not break.

2) Many people have asked and look for ways to authenticate...when they do the trick is then having the client support it.  I reviewed the lib your useing for request and it supports http basic auth as well as https protocol.  I've modified the code to allow additional options to be specified which you can use to accomplish requests with http auth inplain text or http auth encrypted or by default connect without authentication at all.

Please review the changes, I've run the vows tests (online and offline) to vet the code as is, further testing in my environment which uses nginx as a reverse proxy with authentication and the use of percolate on my bulk indexes is working great.

Thanks.
