### PR TITLE
Support for latest Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 
     "engines": [
         "node >=0.4.0 <0.7.0",
-        "npm ~1.0.0"
+        "npm >=1.0.0"
     ],
 
     "dependencies": {


### PR DESCRIPTION
Node 0.6.5 integrates npm 1.1.0-alpha6.

```
npm ERR! Unsupported
npm ERR! Not compatible with your version of node/npm: elastical@0.0.5
npm ERR! Required: ["node >=0.4.0 <0.7.0","npm ~1.0.0"]
npm ERR! Actual:   {"npm":"1.1.0-alpha-6","node":"0.6.5"}
npm ERR! 
npm ERR! System Linux 3.1.4-1-ARCH
npm ERR! command "node" "/usr/bin/npm" "install" "elastical"
npm ERR! cwd /home/vrtak-cz/Data/Workspace/Nette/jabber
npm ERR! node -v v0.6.5
npm ERR! npm -v 1.1.0-alpha-6
npm ERR! code ENOTSUP
npm ERR! message Unsupported
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /home/vrtak-cz/Data/Workspace/Nette/jabber/npm-debug.log
npm not ok
```
