### PR TITLE
Scrolling does not work

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -470,7 +470,7 @@ Client.prototype = {
             callback = options;
             options  = {};
         }
-
+				var useScrollingEndpoint = (options.scroll_id != null);
         // Create a copy of options so we can modify it.
         options = util.merge(options || {});
 
@@ -522,6 +522,10 @@ Client.prototype = {
         hasOptions = !!Object.keys(options).length;
 
         url += '/_search';
+
+				if(useScrollingEndpoint){
+					url += '/scroll';
+				}
 
         if (query.length) {
             url += '?' + query.join('&');

--- a/tests/offline-tests.js
+++ b/tests/offline-tests.js
@@ -602,8 +602,76 @@ vows.describe('Elastical').addBatch({
                 }
             },
 
-            'with options': {
+            'with options but no scroll_id': {
                 topic: function (client) {
+                    client._testHook = this.callback;
+                    client.search({
+                        query        : {query_string: {query: 'foo'}},
+                        explain      : true,
+                        facets       : {},
+                        fields       : ['one', 'two'],
+                        filter       : {},
+                        from         : 3,
+                        highlight    : {},
+                        index        : 'blog',
+                        indices_boost: {},
+                        min_score    : 0.5,
+                        preference   : '_primary',
+                        routing      : 'hashyhash',
+                        script_fields: {},
+                        scroll       : '1m',
+                        search_type  : 'query_and_fetch',
+                        size         : 42,
+                        sort         : {},
+                        timeout      : '15s',
+                        track_scores : true,
+                        type         : 'post',
+                        version      : true
+                    }, function () {});
+                },
+
+                'method should be POST': function (err, options) {
+                    assert.equal(options.method, 'POST');
+                },
+
+                'URL should have the correct path': function (err, options) {
+                    assert.equal(parseUrl(options.url).pathname, '/blog/post/_search');
+                },
+
+                'URL query string should contain the correct parameters': function (err, options) {
+                    var query = parseUrl(options.url, true).query;
+
+                    assert.deepEqual({
+                        preference : '_primary',
+                        routing    : 'hashyhash',
+                        scroll     : '1m',
+                        search_type: 'query_and_fetch',
+                        timeout    : '15s'
+                    }, query);
+                },
+
+                'request body should contain the correct options': function (err, options) {
+                    assert.deepEqual({
+                        query        : {query_string: {query: 'foo'}},
+                        explain      : true,
+                        facets       : {},
+                        fields       : ['one', 'two'],
+                        filter       : {},
+                        from         : 3,
+                        highlight    : {},
+                        indices_boost: {},
+                        min_score    : 0.5,
+                        script_fields: {},
+                        size         : 42,
+                        sort         : {},
+                        track_scores : true,
+                        version      : true
+                    }, options.json);
+                },
+            },
+
+            'with options and scroll_id': {
+							topic: function (client) {
                     client._testHook = this.callback;
                     client.search({
                         query        : {query_string: {query: 'foo'}},
@@ -631,12 +699,8 @@ vows.describe('Elastical').addBatch({
                     }, function () {});
                 },
 
-                'method should be POST': function (err, options) {
-                    assert.equal(options.method, 'POST');
-                },
-
                 'URL should have the correct path': function (err, options) {
-                    assert.equal(parseUrl(options.url).pathname, '/blog/post/_search');
+                    assert.equal(parseUrl(options.url).pathname, '/blog/post/_search/scroll');
                 },
 
                 'URL query string should contain the correct parameters': function (err, options) {
@@ -650,25 +714,6 @@ vows.describe('Elastical').addBatch({
                         search_type: 'query_and_fetch',
                         timeout    : '15s'
                     }, query);
-                },
-
-                'request body should contain the correct options': function (err, options) {
-                    assert.deepEqual({
-                        query        : {query_string: {query: 'foo'}},
-                        explain      : true,
-                        facets       : {},
-                        fields       : ['one', 'two'],
-                        filter       : {},
-                        from         : 3,
-                        highlight    : {},
-                        indices_boost: {},
-                        min_score    : 0.5,
-                        script_fields: {},
-                        size         : 42,
-                        sort         : {},
-                        track_scores : true,
-                        version      : true
-                    }, options.json);
                 }
             },
 

--- a/tests/online-tests.js
+++ b/tests/online-tests.js
@@ -602,7 +602,7 @@ vows.describe('Elastical')
                 },
 
                 'should have a scroll_id': function (err, results, res) {
-                		 assert.isNotNull(res._scroll_id);
+                    assert.isNotNull(res._scroll_id);
                     assert.isNull(err);
                     assert.isObject(results);
                     assert.isObject(res);

--- a/tests/online-tests.js
+++ b/tests/online-tests.js
@@ -590,6 +590,26 @@ vows.describe('Elastical')
                     assert.isArray(results.hits);
                     assert.strictEqual(res.hits, results);
                 }
+            },
+
+            'simple scrolling query':{
+							topic: function (client) {
+                    client.search({
+                        index: 'elastical-test-get',
+                        query: {match_all: {}},
+                        scroll: '1m'
+                    }, this.callback);
+                },
+
+                'should have a scroll_id': function (err, results, res) {
+                		 assert.isNotNull(res._scroll_id);
+                    assert.isNull(err);
+                    assert.isObject(results);
+                    assert.isObject(res);
+                    assert.equal(1, results.total);
+                    assert.isArray(results.hits);
+                    assert.strictEqual(res.hits, results);
+                }
             }
         },
 


### PR DESCRIPTION
elastical was not working with scrolling in elasticsearch > 0.18. I believe the issue was that the query url need to end in '/scroll' in addition to passing the scroll_id. 
