### PR TITLE
Fix `ActionRequestValidationException[Validation Failed: 1: search sourc...

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -529,7 +529,7 @@ Client.prototype = {
 
         this._request(url, {
             method: hasOptions ? 'POST' : 'GET',
-            json  : hasOptions ? options : undefined
+            json  : hasOptions ? options : {}
         }, function (err, res) {
             if (err) { return callback(err, null, res), undefined; }
             callback(null, res.hits, res);


### PR DESCRIPTION
Fix `ActionRequestValidationException[Validation Failed: 1: search source is missing;]` with elastic-search 0.18.6

You can reproduce the same issue with ES example : 

```
$ curl -XPUT http://localhost:9201/twitter/tweet/2 -d '{
    "user": "kimchy",
    "post_date": "2009-11-15T14:12:12",
    "message": "You know, for Search"
}'

$ curl -XGET http://localhost:9200/twitter/_search 
{"error":"ActionRequestValidationException[Validation Failed: 1: search source is missing;]","status":500}

$ curl -XGET http://localhost:9200/twitter/_search -d {}
{"took":3,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":1,"max_score":1.0,"hits":[{"_index":"twitter","_type":"tweet","_id":"2","_score":1.0, "_source" : {
    "user": "kimchy",
    "post_date": "2009-11-15T14:12:12",
    "message": "You know, for Search"
}}]}}
```
