### PR TITLE
lock request version at 2.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     ],
 
     "dependencies": {
-        "request": "~2.9.3"
+        "request": "=2.9.1"
     },
 
     "devDependencies": {


### PR DESCRIPTION
I didn't have time to look more deeply into what changed in request 2.9.2, but this solved my issue in the meantime.
