### PR TITLE
Expose request

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -543,7 +543,7 @@ Client.prototype = {
             url += '?' + query.join('&');
         }
 
-        this._request(url, {
+        return this._request(url, {
             method: hasOptions ? 'POST' : 'GET',
             json  : hasOptions ? options : {}
         }, function (err, res) {
@@ -728,7 +728,7 @@ Client.prototype = {
             return this._testHook(null, options), undefined;
         }
 
-        request(url, options, function (err, res, body) {
+        return request(url, options, function (err, res, body) {
             if (err) { return callback(err), undefined; }
 
             // The request module will automatically try to parse the

--- a/lib/client.js
+++ b/lib/client.js
@@ -714,7 +714,20 @@ Client.prototype = {
 
         options = util.merge(options);
         options.uri = url;
-        options.timeout || (options.timeout = this.options.timeout);
+
+        [ 'timeout',
+          'pool',
+          'agent',
+          'headers',
+          'followRedirect',
+          'followAllRedirects',
+          'proxy',
+          'oauth',
+          'strictSSL',
+          'jar'].forEach(function(key){
+          if(this.options[key] == null) return
+          options[key] || (options[key] = this.options[key]);
+        }, this);
 
         // Write executable curl commands to stderr for easier debugging when
         // this client's curlDebug option is true.

--- a/lib/index.js
+++ b/lib/index.js
@@ -177,7 +177,7 @@ Index.bulk = function (client, operations, options, callback) {
         url += '?' + query.join('&');
     }
 
-    client._request(url, {
+    return client._request(url, {
         method: 'PUT',
         body  : body.join('\n') + '\n'
     }, callback);
@@ -205,7 +205,7 @@ Index.create = function (client, name, options, callback) {
         options  = {};
     }
 
-    client._request('/' + encode(name), {
+    return client._request('/' + encode(name), {
         method: 'PUT',
         json  : options
     }, callback && function (err, data) {
@@ -241,7 +241,7 @@ Index.delete = function (client, names, callback) {
         names = names.join(',');
     }
 
-    client._request('/' + encode(names || ''), {method: 'DELETE'}, callback);
+    return client._request('/' + encode(names || ''), {method: 'DELETE'}, callback);
 };
 
 /**
@@ -264,7 +264,7 @@ Index.exists = function (client, names, callback) {
         names = names.join(',');
     }
 
-    client._request('/' + encode(names), {method: 'HEAD'}, function (err) {
+    return client._request('/' + encode(names), {method: 'HEAD'}, function (err) {
         callback(null, !err);
     });
 };
@@ -318,7 +318,7 @@ Index.count = function (client, names, type, query, callback) {
       url += '?q=*';
     }
 
-    client._request(url, callback);
+    return client._request(url, callback);
 }
 
 /**
@@ -357,7 +357,7 @@ Index.getMapping = function (client, names, type, callback) {
 
     url += '/_mapping';
 
-    client._request(url, callback);
+    return client._request(url, callback);
 }
 
 /**
@@ -394,7 +394,7 @@ Index.putMapping = function (client, names, type, mapping, callback) {
 
     names || (names = '_all');
 
-    client._request('/' + encode(names) + '/' + encode(type) + '/_mapping', {
+    return client._request('/' + encode(names) + '/' + encode(type) + '/_mapping', {
         method: 'PUT',
         json: mapping
     }, callback);
@@ -427,7 +427,7 @@ Index.refresh = function (client, names, callback) {
 
     names || (names = '_all');
 
-    client._request('/' + encode(names) + '/_refresh', {method: 'POST'},
+    return client._request('/' + encode(names) + '/_refresh', {method: 'POST'},
         callback);
 };
 
@@ -446,7 +446,7 @@ Registers a river with the cluster.
 @static
 **/
 Index.putRiver = function( client, name, config, callback ){
-    client._request('/_river/' + name + '/_meta', {
+    return client._request('/_river/' + name + '/_meta', {
         method: 'PUT',
         json: config
     }, callback);
@@ -466,7 +466,7 @@ Gets river config from the cluster.
 @static
 **/
 Index.getRiver = function( client, name, callback ){
-    client._request('/_river/' + name + '/_meta', { method: 'GET' }, callback);
+    return client._request('/_river/' + name + '/_meta', { method: 'GET' }, callback);
 };
 
 /**
@@ -483,7 +483,7 @@ Deletes a river config from the cluster.
 @static
 **/
 Index.deleteRiver = function( client, name, callback ){
-    client._request('/_river/' + name, { method: 'DELETE' }, callback);
+    return client._request('/_river/' + name, { method: 'DELETE' }, callback);
 };
 
 Index.prototype = {
@@ -553,7 +553,7 @@ Index.prototype = {
             url += '?' + query.join('&');
         }
 
-        this.client._request(url, {method: 'DELETE'}, function (err, res) {
+        return this.client._request(url, {method: 'DELETE'}, function (err, res) {
             if (err) {
                 if (ignoreMissing && res && res.found === false) {
                     return callback(null, res), undefined;
@@ -677,7 +677,7 @@ Index.prototype = {
             url += '?' + query.join('&');
         }
 
-        this.client._request(url, {method: 'GET'}, function (err, res) {
+        return this.client._request(url, {method: 'GET'}, function (err, res) {
             if (err) {
                 if (ignoreMissing && res && (res.exists === false
                         || res.error.indexOf('IndexMissing') !== -1)) {
@@ -808,7 +808,7 @@ Index.prototype = {
             url += '?' + query.join('&');
         }
 
-        this.client._request(url, {
+        return this.client._request(url, {
             method: id ? 'PUT' : 'POST',
             json  : doc
         }, callback);
@@ -970,7 +970,7 @@ Index.prototype = {
         var url = '/_percolator/';
         url += this.name;
         url += '/'+encode(percolator);
-        this.client._request(url, {
+        return this.client._request(url, {
             method: 'POST',
             json  : query
         }, callback);
@@ -993,7 +993,7 @@ Index.prototype = {
      */
     getPercolator: function(percolator, callback){
         var url = '/_percolator/'+this.name+'/'+encode(percolator);
-        this.client._request(url, {
+        return this.client._request(url, {
             method: 'GET'
         }, function (err, res) {
             if (err) { return callback(err, null, res), undefined; }
@@ -1033,7 +1033,7 @@ Index.prototype = {
             doc = {'doc': doc};
         }
         var url = '/'+ this.name+'/'+type+'/_percolate';
-        this.client._request(url, {
+        return this.client._request(url, {
             method: 'GET',
             json  : doc
         }, callback);
@@ -1054,7 +1054,7 @@ Index.prototype = {
      */
     deletePercolator: function(percolator, callback){
         var url = '/_percolator/'+ this.name +'/'+encode(percolator);
-        this.client._request(url, {
+        return this.client._request(url, {
             method: 'DELETE'
         }, callback);
     }

--- a/tests/offline-tests.js
+++ b/tests/offline-tests.js
@@ -919,6 +919,18 @@ vows.describe('Elastical').addBatch({
         }
     },
 
+    'Client with custom request options': {
+        topic: function(){
+          var client = new elastical.Client({pool: { maxSockets: 10 }})
+          client._testHook = this.callback;
+          client.get('blog', '1');
+        },
+
+        'the option should be passed to request': function (err, options) {
+            assert.equal(options.pool.maxSockets, 10);
+        }
+    },
+
     'Index': {
         topic: new elastical.Client().getIndex('foo'),
 

--- a/tests/online-tests.js
+++ b/tests/online-tests.js
@@ -15,7 +15,7 @@ vows.describe('Elastical')
         '`bulk()`': {
             'when the index exists': {
                 topic: function (client) {
-                    client.bulk([
+                    this.req = client.bulk([
                         {create: {index: 'elastical-test-bulk', type: 'post', id: 'foo', data: {
                             a: 'a',
                             b: 'b'
@@ -44,13 +44,14 @@ vows.describe('Elastical')
                     assert.isTrue(res.items[2].index.ok);
                     assert.equal(res.items[2].index.matches[0], 'perc');
                     assert.isTrue(res.items[3].delete.ok);
+                    assert.isDefined(this.req);
                 }
             }
         },
 
         '`createIndex()`': {
             topic: function (client) {
-                client.createIndex('elastical-test', this.callback);
+                this.req = client.createIndex('elastical-test', this.callback);
             },
 
             teardown: function (index) {
@@ -63,6 +64,7 @@ vows.describe('Elastical')
                 assert.equal(index.name, 'elastical-test');
                 assert.isObject(data);
                 assert.isTrue(data.ok);
+                assert.isDefined(this.req);
             },
 
             'when the index already exists': {
@@ -80,13 +82,14 @@ vows.describe('Elastical')
         '`delete()`': {
             'when called with no options': {
                 topic: function (client) {
-                    client.delete('elastical-test-delete', 'post', '1', this.callback);
+                    this.req = client.delete('elastical-test-delete', 'post', '1', this.callback);
                 },
 
                 'should delete the given document': function (err, res) {
                     assert.isNull(err);
                     assert.isObject(res);
                     assert.isTrue(res.found);
+                    assert.isDefined(this.req);
                 }
             },
 
@@ -127,7 +130,7 @@ vows.describe('Elastical')
         '`get()`': {
             'when called with no options': {
                 topic: function (client) {
-                    client.get('elastical-test-get', '1', this.callback);
+                    this.req = client.get('elastical-test-get', '1', this.callback);
                 },
 
                 'should get a document': function (err, doc, res) {
@@ -141,6 +144,8 @@ vows.describe('Elastical')
                     assert.include(doc, 'tags');
 
                     assert.isArray(doc.tags);
+
+                    assert.isDefined(this.req);
                 }
             },
 
@@ -275,7 +280,7 @@ vows.describe('Elastical')
         '`index()`': {
             'when called with no options': {
                 topic: function (client) {
-                    client.index('elastical-test-index', 'post', {
+                    this.req = client.index('elastical-test-index', 'post', {
                         title  : "Welcome to my stupid blog",
                         content: "This is the first and last time I'll post anything.",
                         tags   : ['welcome', 'first post', 'last post'],
@@ -290,6 +295,7 @@ vows.describe('Elastical')
                     assert.equal(res._index, 'elastical-test-index');
                     assert.equal(res._type, 'post');
                     assert.equal(res._version, 1);
+                    assert.isDefined(this.req);
                 }
             },
 
@@ -328,12 +334,13 @@ vows.describe('Elastical')
             'when called with a single index name': {
                 'which exists': {
                     topic: function (client) {
-                        client.indexExists('elastical-test-indexexists', this.callback);
+                        this.req = client.indexExists('elastical-test-indexexists', this.callback);
                     },
 
                     'should respond with `true`': function (err, exists) {
                         assert.isNull(err);
                         assert.isTrue(exists);
+                        assert.isDefined(this.req);
                     }
                 },
 
@@ -379,13 +386,14 @@ vows.describe('Elastical')
         '`putMapping()`': {
             'with no index': {
                 topic: function (client) {
-                    client.putMapping('tweet', { tweet: { properties: { message: { type: 'string', store: 'yes' }}}}, this.callback);
+                    this.req = client.putMapping('tweet', { tweet: { properties: { message: { type: 'string', store: 'yes' }}}}, this.callback);
                 },
 
                 'should succeed': function (err, res) {
                     assert.isNull(err);
                     assert.isObject(res);
                     assert.isTrue(res.ok);
+                    assert.isDefined(this.req);
                 }
             },
 
@@ -433,7 +441,7 @@ vows.describe('Elastical')
         '`getMapping()`': {
             'of a specific type within a specific index': {
                 topic: function (client) {
-                    client.getMapping('elastical-test-mapping', 'type', this.callback);
+                    this.req = client.getMapping('elastical-test-mapping', 'type', this.callback);
                 },
                 'should succeed': function (err, res) {
                     assert.isNull(err);
@@ -444,6 +452,7 @@ vows.describe('Elastical')
                     assert.isObject(res.type.properties.title);
                     assert.equal(res.type.properties.body.type, 'string');
                     assert.equal(res.type.properties.tags.type, 'string');
+                    assert.isDefined(this.req);
                 }
             },
 
@@ -503,12 +512,13 @@ vows.describe('Elastical')
         '`count()`': {
             'with a query': {
                 topic: function (client) {
-                  client.count('elastical-test-mapping2', 'type', 'tags:ho', this.callback);
+                  this.req = client.count('elastical-test-mapping2', 'type', 'tags:ho', this.callback);
                 },
                 'should succeed': function (err, res) {
                     assert.isNull(err);
                     assert.isObject(res);
                     assert.equal(res.count, 1);
+                    assert.isDefined(this.req);
                 }
             },
             'with no query': {
@@ -546,7 +556,7 @@ vows.describe('Elastical')
         '`refresh()`': {
             'with no index': {
                 topic: function (client) {
-                    client.refresh(this.callback);
+                    this.req = client.refresh(this.callback);
                 },
 
                 'should succeed': function (err, res) {
@@ -554,6 +564,7 @@ vows.describe('Elastical')
                     assert.isObject(res);
                     assert.isTrue(res.ok);
                     assert.isObject(res._shards);
+                    assert.isDefined(this.req);
                 }
             },
 
@@ -601,7 +612,7 @@ vows.describe('Elastical')
         '`search()`': {
             'simple string query': {
                 topic: function (client) {
-                    client.search({
+                    this.req = client.search({
                         index: 'elastical-test-get',
                         query: 'hello'
                     }, this.callback);
@@ -614,6 +625,7 @@ vows.describe('Elastical')
                     assert.equal(1, results.total);
                     assert.isArray(results.hits);
                     assert.strictEqual(res.hits, results);
+                    assert.isDefined(this.req);
                 }
             },
 
@@ -658,35 +670,38 @@ vows.describe('Elastical')
 
         '`putRiver()`': {
             topic: function (client) {
-                client.putRiver( 'elastical-test-river', 'elastical-test-river-put', { type:'dummy' }, this.callback );	
+                this.req = client.putRiver( 'elastical-test-river', 'elastical-test-river-put', { type:'dummy' }, this.callback.bind(this) );	
             },
 
             'should return ok': function (err, results, res) {
                 assert.equal(results.ok,true);
                 assert.equal(results._index,'_river');
                 assert.equal(results._type,'elastical-test-river-put');
+                assert.isDefined(this.req);
             }
         },
 
         '`getRiver()`': {
             topic: function (client) {
-                client.getRiver( 'elastical-test-river', 'elastical-test-river-get', this.callback );	
+                this.req = client.getRiver( 'elastical-test-river', 'elastical-test-river-get', this.callback.bind(this) );	
             },
 
             'should return ok': function (err, results, res) {
                 assert.equal(results._type,"elastical-test-river-get");
                 assert.equal(results.exists,true);
                 assert.equal(results._source.type,"dummy");
+                assert.isDefined(this.req);
             }
         },
 
         '`deleteRiver()`': {
             topic: function (client) {
-                client.deleteRiver( 'elastical-test-river', 'elastical-test-river-delete', this.callback );	
+                this.req = client.deleteRiver( 'elastical-test-river', 'elastical-test-river-delete', this.callback.bind(this) );	
             },
 
             'should return ok': function (err, results, res) {
                 assert.equal(results.ok,true);
+                assert.isDefined(this.req);
             }
         }
     }
@@ -696,7 +711,7 @@ vows.describe('Elastical')
         topic: new elastical.Client(),
         '`setPercolator()`':{
             topic: function(client){
-                client.setPercolator('elastical-test-percolator-index',
+                this.req = client.setPercolator('elastical-test-percolator-index',
                                   'elastical-test-percolator-set',
                                   {
                                     "query" : {
@@ -717,11 +732,12 @@ vows.describe('Elastical')
                 assert.equal(res._index, "_percolator");
                 assert.equal(res._type, "elastical-test-percolator-index");
                 assert.equal(res._id, "elastical-test-percolator-set");
+                assert.isDefined(this.req);
             }
         },
         '`getPercolator()`': {
             topic: function (client) {
-                client.getPercolator('elastical-test-percolator-index',
+                this.req = client.getPercolator('elastical-test-percolator-index',
                                     'elastical-test-percolator-get',
                                     this.callback);
             },
@@ -743,12 +759,13 @@ vows.describe('Elastical')
                 assert.equal('elastical-test-percolator-index', res._type);
                 assert.equal('elastical-test-percolator-get', res._id);
                 assert.equal(true, res.exists);
+                assert.isDefined(this.req);
             }
         },
         '`percolate()`': {
             'should return a match and the name of the percolator': {
                 topic: function(client){
-                    client.percolate('elastical-test-percolator-index', 'post', {
+                    this.req = client.percolate('elastical-test-percolator-index', 'post', {
                         doc: {
                             title  : "Welcome to my stupid blog",
                             content: "This is the first and last time I'll post anything.",
@@ -764,6 +781,7 @@ vows.describe('Elastical')
                         ok: true,
                         matches: [ 'elastical-test-percolator-get' ]
                     }, res);
+                    assert.isDefined(this.req);
                 }
             },
             'should return a match and the name of the percolator even if doc is absent': {
@@ -787,7 +805,7 @@ vows.describe('Elastical')
         },
         '`deletePercolator()`': {
             topic: function (client) {
-                client.deletePercolator('elastical-test-percolator-index',
+                this.req = client.deletePercolator('elastical-test-percolator-index',
                                     'elastical-test-percolator-delete',
                                     this.callback);
             },
@@ -799,6 +817,7 @@ vows.describe('Elastical')
                 assert.equal(res._index, '_percolator');
                 assert.equal(res._type, 'elastical-test-percolator-index');
                 assert.equal(res._id, 'elastical-test-percolator-delete');
+                assert.isDefined(this.req);
             }
         }
     }


### PR DESCRIPTION
Hi, 

I would like to listen on http events like `error`, `timeout`, to debug my application more easily.
In this pull request I expose the http request in the node-elastical API.

Could you try the online-tests before merge ? The rivers fails, but it could be because of my ES configuration.

Cheers
Romain
