### PR TITLE
Allow option to specify path of _bulk endpoint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -137,7 +137,7 @@ Index.bulk = function (client, operations, options, callback) {
         url   = '/_bulk';
 
     if (options.index) {
-        url = '/' + options.index + '/_bulk';
+        url = '/' + encode(options.index) + '/_bulk';
         delete options.index;
     }
 


### PR DESCRIPTION
This fix is intended to correct an issue when working with a shared cluster service that locks down the root endpoints and only allows operations against the specified index.

Bulk method now parses the index option if present into the endpoint path.

Test case updated and additional test added for this option.
