### PR TITLE
ability to pass in a URL to configure elastical.Client

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -48,11 +48,24 @@ function Client(host, options) {
         host    = undefined;
     }
 
-    this.host    = host || '127.0.0.1';
     this.options = options || {};
 
-    this.options.port || (this.options.port = 9200);
-    this.options.protocol || (this.options.protocol = 'http');
+    if(this.options.url) {
+      var Url = require('url')
+        , urlObject = Url.parse(options.url);
+
+      this.host = urlObject.host;
+      this.options.port = (urlObject.port || 9200);
+      this.options.protocol = (urlObject.protocol || 'http');
+      this.options.basePath = (urlObject.path || '');
+
+    } else {
+      this.host    = host || '127.0.0.1';
+      this.options.port || (this.options.port = 9200);
+      this.options.protocol || (this.options.protocol = 'http');
+      this.options.basePath || (this.options.basePath = '');
+    }
+
     this.options.timeout || (this.options.timeout = 60000);
 
     this._indexCache = {};
@@ -85,7 +98,7 @@ Client.prototype = {
     get baseUrl() {
         return this.options.protocol + '://' +
             (this.options.auth ? this.options.auth + '@' : '') +
-            this.host + ':' + this.options.port;
+            this.host + ':' + this.options.port + this.options.basePath;
     },
 
     /**


### PR DESCRIPTION
Makes using node-elastical on heroku with Bonsai more straight forward.

new elastical.Client({url: process.env.BONSAI_INDEX_URL});
