### PR TITLE
set request options

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -714,7 +714,20 @@ Client.prototype = {
 
         options = util.merge(options);
         options.uri = url;
-        options.timeout || (options.timeout = this.options.timeout);
+
+        [ 'timeout',
+          'pool',
+          'agent',
+          'headers',
+          'followRedirect',
+          'followAllRedirects',
+          'proxy',
+          'oauth',
+          'strictSSL',
+          'jar'].forEach(function(key){
+          if(this.options[key] == null) return
+          options[key] || (options[key] = this.options[key]);
+        }, this);
 
         // Write executable curl commands to stderr for easier debugging when
         // this client's curlDebug option is true.

--- a/tests/offline-tests.js
+++ b/tests/offline-tests.js
@@ -919,6 +919,18 @@ vows.describe('Elastical').addBatch({
         }
     },
 
+    'Client with custom request options': {
+        topic: function(){
+          var client = new elastical.Client({pool: { maxSockets: 10 }})
+          client._testHook = this.callback;
+          client.get('blog', '1');
+        },
+
+        'the option should be passed to request': function (err, options) {
+            assert.equal(options.pool.maxSockets, 10);
+        }
+    },
+
     'Index': {
         topic: new elastical.Client().getIndex('foo'),
 


### PR DESCRIPTION
Hi,

I would like to change the default agent of Elastical to this one : 
https://github.com/TBEDP/agentkeepalive

To do it, I need to set request options.

```
var Agent = require('agentkeepalive');

var keepaliveAgent = new Agent({
  maxSockets: 10,
  maxKeepAliveRequests: 0, // max requests per keepalive socket, default is 0, no limit.
  maxKeepAliveTime: 30000 // keepalive for 30 seconds
});

var client = new elastical.Client({agent: keepaliveAgent })
```

I  set a list of allowed options, tell me if it's ok for you : 

```
[ 'timeout',
  'pool',
  'agent',
  'headers',
  'followRedirect',
  'followAllRedirects',
  'proxy',
  'oauth',
  'strictSSL',
  'jar']
```

Cheers
Romain
